### PR TITLE
fixes bug with having to hit space twice

### DIFF
--- a/qml/platform.qtcontrols/SearchFieldPL.qml
+++ b/qml/platform.qtcontrols/SearchFieldPL.qml
@@ -26,6 +26,7 @@ TextField {
     anchors.leftMargin: styler.themeHorizontalPageMargin
     anchors.right: parent.right
     anchors.rightMargin: styler.themeHorizontalPageMargin
+    inputMethodHints: Qt.ImhNoPredictiveText
     focus: true
     leftPadding: searchButton.width + searchButton.anchors.leftMargin + styler.themePaddingMedium
     rightPadding: clearButton.width + clearButton.anchors.leftMargin + styler.themePaddingMedium


### PR DESCRIPTION
fix bug where you have to hit space twice to create a space in search field.

since spellcheck is not very good with numbers, and proper place names, use  inputMethodHints: Qt.ImhNoPredictiveText 
predictive text is finicky on ubports - conflicting with ontextchanged (could use ontextcompleted, but would not show letter for letter suggestions in app)